### PR TITLE
UC-2: As a user I can see the correct connection status

### DIFF
--- a/src/ui/components/ConnectionStatusLabel.tsx
+++ b/src/ui/components/ConnectionStatusLabel.tsx
@@ -1,0 +1,19 @@
+import { ConnectionStatus } from '@/models/ConnectionStatus';
+import { Typography } from '@mui/material';
+import React from 'react';
+
+interface Props {
+  connectionStatus: ConnectionStatus;
+}
+
+const ConnectionStatusLabel: React.FC<Props> = ({ connectionStatus }) => {
+  const isOnline = connectionStatus === ConnectionStatus.Online;
+
+  return (
+    <Typography color={isOnline ? 'success.main' : 'warning.main'}>
+      {connectionStatus}
+    </Typography>
+  );
+};
+
+export default ConnectionStatusLabel;

--- a/src/ui/components/DoorDetail.tsx
+++ b/src/ui/components/DoorDetail.tsx
@@ -2,6 +2,7 @@ import Typography from '@mui/material/Typography';
 import { Door } from '@/models/Door';
 import { DetailPageContainer } from '@/ui/layout/DetailPageContainer';
 import { DetailPageItem } from '@/ui/layout/DetailPageItem';
+import ConnectionStatusLabel from './ConnectionStatusLabel';
 
 interface DoorDetailProps {
   door: Door;
@@ -23,7 +24,7 @@ export function DoorDetail({ door }: DoorDetailProps) {
         <Typography>{door.connectionType}</Typography>
       </DetailPageItem>
       <DetailPageItem label="Connection status">
-        <Typography color="success.main">online</Typography>
+        <ConnectionStatusLabel connectionStatus={door.connectionStatus} />
       </DetailPageItem>
     </DetailPageContainer>
   );

--- a/src/ui/components/DoorList.tsx
+++ b/src/ui/components/DoorList.tsx
@@ -3,6 +3,8 @@ import { useCallback } from 'react';
 import { Door } from '@/models/Door';
 import { DataGrid, GridColDef, GridRowParams } from '@mui/x-data-grid';
 import Typography from '@mui/material/Typography';
+import { ConnectionStatus } from '@/models/ConnectionStatus';
+import ConnectionStatusLabel from './ConnectionStatusLabel';
 
 interface DoorListProps {
   doors: Door[];
@@ -33,10 +35,9 @@ const columns: GridColDef<Door>[] = [
     field: 'connectionStatus',
     headerName: 'Connection status',
     flex: 1,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    renderCell: ({ row: door }) => {
-      return <Typography color="success.main">online</Typography>;
-    },
+    renderCell: ({ row: door }) => (
+      <ConnectionStatusLabel connectionStatus={door.connectionStatus} />
+    ),
   },
 ];
 

--- a/src/ui/components/DoorList.tsx
+++ b/src/ui/components/DoorList.tsx
@@ -2,8 +2,6 @@ import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { Door } from '@/models/Door';
 import { DataGrid, GridColDef, GridRowParams } from '@mui/x-data-grid';
-import Typography from '@mui/material/Typography';
-import { ConnectionStatus } from '@/models/ConnectionStatus';
 import ConnectionStatusLabel from './ConnectionStatusLabel';
 
 interface DoorListProps {

--- a/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
@@ -77,9 +77,9 @@ exports[`DoorDetail should render correctly 1`] = `
       </strong>
     </p>
     <p
-      class="MuiTypography-root MuiTypography-body1 css-18todbp-MuiTypography-root"
+      class="MuiTypography-root MuiTypography-body1 css-1oykq5t-MuiTypography-root"
     >
-      online
+      offline
     </p>
   </div>
 </div>


### PR DESCRIPTION
Fix the bug where "connection status" is always "online" despite some of the doors being "offline". The real estate manager (application user) must have the correct information to check which doors are connected to the IoT server and which ones potentially have connection issues.

- [x] Door list displays correct connection status
- [x] Door details page displays correct connection status
- [x] Related tests pass
- [x] No lint errors
- [x] Build passes