### PR TITLE
UC-4: Refactor datetime unit tests

### DIFF
--- a/src/lib/dateTime.test.ts
+++ b/src/lib/dateTime.test.ts
@@ -1,10 +1,12 @@
 import { DateTime, Settings } from 'luxon';
 import { getLocaleString, getDateTimeByJSDateOrISO } from './dateTime';
 
-Settings.defaultZone = 'Europe/Zurich';
-Settings.defaultLocale = 'de';
-
 describe('dateTime', () => {
+  beforeAll(() => {
+    Settings.defaultZone = 'Europe/Zurich';
+    Settings.defaultLocale = 'de';
+  });
+
   describe('getDateTimeByJSDateOrISO', () => {
     it('returns a luxon DateTime when a string is passed', () => {
       const result = getDateTimeByJSDateOrISO('2000-01-01');
@@ -30,24 +32,24 @@ describe('dateTime', () => {
     });
 
     it('should handle Date object and return formatted short time string', () => {
-      const date = new Date('2023-02-12T14:30:20.124');
+      const date = new Date('2023-02-12T14:30:20.124Z');
       const formattedDate = getLocaleString(date, DateTime.TIME_SIMPLE);
 
-      expect(formattedDate).toEqual('14:30');
+      expect(formattedDate).toEqual('15:30');
     });
 
     it('should handle Date object and return formatted short date and time string', () => {
-      const date = new Date('2023-02-12T14:30:20.124');
+      const date = new Date('2023-02-12T14:30:20.124Z');
       const formattedDate = getLocaleString(date, DateTime.DATETIME_SHORT);
 
-      expect(formattedDate).toEqual('12.2.2023, 14:30');
+      expect(formattedDate).toEqual('12.2.2023, 15:30');
     });
 
     it('should handle Date object and return formatted short date and time string by default', () => {
-      const date = new Date('2023-02-12T14:30:20.124');
+      const date = new Date('2023-02-12T14:30:20.124Z');
       const formattedDate = getLocaleString(date);
 
-      expect(formattedDate).toEqual('12.2.2023, 14:30');
+      expect(formattedDate).toEqual('12.2.2023, 15:30');
     });
 
     it('should handle ISO string and return formatted short date and time string', () => {


### PR DESCRIPTION
The timezones in the unit tests were not properly set up, causing flaky tests depending on the users TZ. 


- [x] Set the luxon Settings.defaultZone & Settings.defaultLocale in a `beforeAll` hook
- [x] Provide offset info in the date passed to the date functions
- [x] All related tests pass
- [x] No lint errors
- [x] Build passes