### PR TITLE
UC-5: Fix 'title with multiple children' warning

### DIFF
--- a/src/pages/doors/[doorId].tsx
+++ b/src/pages/doors/[doorId].tsx
@@ -14,10 +14,12 @@ export default function DoorDetailPage() {
     skip: !isPageQueryParamString(doorId),
   });
 
+  const title = `Door detail: ${door?.name}`;
+
   return (
     <>
       <Head>
-        <title>Door detail: {door?.name}</title>
+        <title>{title}</title>
         <meta name="description" content={`door ${door?.name} detail`} />
       </Head>
       <Layout title={door?.name}>


### PR DESCRIPTION
Next complains about title having multiple children. Issue can be found here: https://github.com/vercel/next.js/discussions/38256

- [x] Warning no longer appears
- [x] All related tests pass
- [x] No lint errors
- [x] Build passes