### PR TITLE
UC-7: Fix Next.js LCP image warning

### DIFF
--- a/src/ui/layout/AppBarLogo.tsx
+++ b/src/ui/layout/AppBarLogo.tsx
@@ -6,7 +6,13 @@ export function AppBarLogo() {
   return (
     <Box sx={{ display: { xs: 'none', md: 'flex' }, mr: 2 }}>
       <Link href="/">
-        <Image src="/logo.png" alt="dormakaba logo" width="269" height="30" />
+        <Image
+          src="/logo.png"
+          priority
+          alt="dormakaba logo"
+          width="269"
+          height="30"
+        />
       </Link>
     </Box>
   );


### PR DESCRIPTION
Next.js complains that the logo is above the fold and is also affecting the lcp. To limit this, we should use the priority flag on the image.

- [x] The warning should not appear in the console of the brouser.
- [x] No TS errors or warnings
- [x] All related tests pass
- [x] No lint errors
- [x] Build passes
