### PR TITLE
UC-8: Add additional unit tests to cover tasks

### DIFF
--- a/src/server/useCases/GetDoorByIdUseCase.test.ts
+++ b/src/server/useCases/GetDoorByIdUseCase.test.ts
@@ -5,6 +5,15 @@ import { DoorDto } from '@/__mocks__/dtos/DoorDto';
 import { DoorRepository } from '@/server/repositories/DoorRepository';
 import { BuildingRepository } from '@/server/repositories/BuildingRepository';
 import { GetDoorByIdUseCase } from './GetDoorByIdUseCase';
+import { ApartmentDto } from '@/__mocks__/dtos/ApartmentDto';
+import { ApartmentRepository } from '../repositories/ApartmentRepository';
+
+const apartmentDto: ApartmentDto = {
+  id: '63f4e0797e85310fee059024',
+  name: 'Apartment 10',
+  floor: 10,
+  building_id: '63f4e0797e85310fee059022',
+};
 
 const buildingDto: BuildingDto = {
   id: '63f4e0797e85310fee059022',
@@ -21,6 +30,7 @@ const doorDto: DoorDto = {
   connection_status: 'online',
   last_connection_status_update: '2023-02-22T22:01:47.573Z',
   building_id: buildingDto.id,
+  apartment_id: '63f4e0797e85310fee059024',
 };
 
 describe('GetDoorByIdUseCase', () => {
@@ -40,10 +50,15 @@ describe('GetDoorByIdUseCase', () => {
       .spyOn(BuildingRepository.prototype, 'getBuildingById')
       .mockImplementation(() => Promise.resolve(buildingDto));
 
+    const getApartmentByIdSpy = jest
+      .spyOn(ApartmentRepository.prototype, 'getApartmentById')
+      .mockImplementation(() => Promise.resolve(apartmentDto));
+
     await getDoorByIdUseCase.execute({ doorId: doorDto.id });
 
     expect(getDoorByIdSpy).toHaveBeenNthCalledWith(1, doorDto.id);
     expect(getBuildingByIdSpy).toHaveBeenNthCalledWith(1, buildingDto.id);
+    expect(getApartmentByIdSpy).toHaveBeenNthCalledWith(1, apartmentDto.id);
   });
 
   it('should throw if no door could be found', async () => {

--- a/src/server/useCases/GetDoorListUseCase.test.ts
+++ b/src/server/useCases/GetDoorListUseCase.test.ts
@@ -3,6 +3,7 @@ import { HttpError } from 'http-errors';
 import { DoorRepository } from '@/server/repositories/DoorRepository';
 import { BuildingRepository } from '@/server/repositories/BuildingRepository';
 import { GetDoorListUseCase } from './GetDoorListUseCase';
+import { ApartmentRepository } from '../repositories/ApartmentRepository';
 
 describe('GetDoorListUseCase', () => {
   let getDoorListUseCase: GetDoorListUseCase;
@@ -21,10 +22,15 @@ describe('GetDoorListUseCase', () => {
       .spyOn(BuildingRepository.prototype, 'getAllBuildings')
       .mockImplementation(() => Promise.resolve([]));
 
+    const getAllApartmentsSpy = jest
+      .spyOn(ApartmentRepository.prototype, 'getAllApartments')
+      .mockImplementation(() => Promise.resolve([]));
+
     await getDoorListUseCase.execute();
 
     expect(getAllDoorsSpy).toHaveBeenCalledTimes(1);
     expect(getAllBuildingsSpy).toHaveBeenCalledTimes(1);
+    expect(getAllApartmentsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should throw if getAllBuildings request fails', async () => {
@@ -35,8 +41,11 @@ describe('GetDoorListUseCase', () => {
     const getAllBuildingsSpy = jest
       .spyOn(BuildingRepository.prototype, 'getAllBuildings')
       .mockImplementation(() => {
-        throw new Error();
+        return Promise.reject(new Error());
       });
+    const getAllApartmentsSpy = jest
+      .spyOn(ApartmentRepository.prototype, 'getAllApartments')
+      .mockImplementation(() => Promise.resolve([]));
 
     try {
       await getDoorListUseCase.execute();
@@ -46,7 +55,8 @@ describe('GetDoorListUseCase', () => {
 
     expect(getAllDoorsSpy).toHaveBeenCalledTimes(1);
     expect(getAllBuildingsSpy).toHaveBeenCalledTimes(1);
+    expect(getAllApartmentsSpy).toHaveBeenCalledTimes(1);
 
-    expect.assertions(3);
+    expect.assertions(4);
   });
 });

--- a/src/ui/components/ConnectionStatusLabel.test.tsx
+++ b/src/ui/components/ConnectionStatusLabel.test.tsx
@@ -1,0 +1,23 @@
+import { render } from '@testing-library/react';
+import ConnectionStatusLabel from './ConnectionStatusLabel';
+import { ConnectionStatus } from '@/models/ConnectionStatus';
+
+describe('ConnectionStatusLabel', () => {
+  describe('with status `online`', () => {
+    it('should render correctly ', () => {
+      const { container } = render(
+        <ConnectionStatusLabel connectionStatus={ConnectionStatus.Online} />,
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('with status `offline`', () => {
+    it('should render correctly ', () => {
+      const { container } = render(
+        <ConnectionStatusLabel connectionStatus={ConnectionStatus.Online} />,
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+});

--- a/src/ui/components/__snapshots__/ConnectionStatusLabel.test.tsx.snap
+++ b/src/ui/components/__snapshots__/ConnectionStatusLabel.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectionStatusLabel with status \`offline\` should render correctly  1`] = `
+<p
+  class="MuiTypography-root MuiTypography-body1 css-18todbp-MuiTypography-root"
+>
+  online
+</p>
+`;
+
+exports[`ConnectionStatusLabel with status \`online\` should render correctly  1`] = `
+<p
+  class="MuiTypography-root MuiTypography-body1 css-18todbp-MuiTypography-root"
+>
+  online
+</p>
+`;

--- a/src/ui/layout/__snapshots__/AppBar.test.tsx.snap
+++ b/src/ui/layout/__snapshots__/AppBar.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`AppBar should render correctly 1`] = `
             data-nimg="1"
             decoding="async"
             height="30"
-            loading="lazy"
             src="/_next/image?url=%2Flogo.png&w=640&q=75"
             srcset="/_next/image?url=%2Flogo.png&w=384&q=75 1x, /_next/image?url=%2Flogo.png&w=640&q=75 2x"
             style="color: transparent;"

--- a/src/ui/layout/__snapshots__/AppBarLogo.test.tsx.snap
+++ b/src/ui/layout/__snapshots__/AppBarLogo.test.tsx.snap
@@ -12,7 +12,6 @@ exports[`AppBarLogo should render correctly 1`] = `
       data-nimg="1"
       decoding="async"
       height="30"
-      loading="lazy"
       src="/_next/image?url=%2Flogo.png&w=640&q=75"
       srcset="/_next/image?url=%2Flogo.png&w=384&q=75 1x, /_next/image?url=%2Flogo.png&w=640&q=75 2x"
       style="color: transparent;"

--- a/src/ui/layout/__snapshots__/Layout.test.tsx.snap
+++ b/src/ui/layout/__snapshots__/Layout.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`Layout should render correctly 1`] = `
             data-nimg="1"
             decoding="async"
             height="30"
-            loading="lazy"
             src="/_next/image?url=%2Flogo.png&w=640&q=75"
             srcset="/_next/image?url=%2Flogo.png&w=384&q=75 1x, /_next/image?url=%2Flogo.png&w=640&q=75 2x"
             style="color: transparent;"


### PR DESCRIPTION
Tasks should be covered by unit tests.


- [x] Unit tests for the new ConnectionStatusLabel component
- [x] Unit tests to cover apartment repository calls when fetching doors
- [x] No TS errors or warnings
- [x] All related tests pass
- [x] No lint errors
- [x] Build passes